### PR TITLE
STUFFS-29 Add social follow/subscribe button component

### DIFF
--- a/apps/api/src/api/site-info/content-types/site-info/schema.json
+++ b/apps/api/src/api/site-info/content-types/site-info/schema.json
@@ -112,6 +112,17 @@
       },
       "component": "general.footer-links",
       "required": true
+    },
+    "socialLinks": {
+      "displayName": "Social Links",
+      "type": "component",
+      "repeatable": true,
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      },
+      "component": "general.social-link"
     }
   }
 }

--- a/apps/api/src/components/general/social-link.json
+++ b/apps/api/src/components/general/social-link.json
@@ -1,0 +1,32 @@
+{
+  "collectionName": "components_general_social_links",
+  "info": {
+    "displayName": "Social Link",
+    "icon": "share",
+    "description": "Social media platform link"
+  },
+  "options": {},
+  "attributes": {
+    "platform": {
+      "type": "enumeration",
+      "enum": [
+        "twitter",
+        "facebook",
+        "instagram",
+        "linkedin",
+        "youtube",
+        "github",
+        "rss",
+        "email"
+      ],
+      "required": true
+    },
+    "url": {
+      "type": "string",
+      "required": true
+    },
+    "label": {
+      "type": "string"
+    }
+  }
+}

--- a/apps/web/components/social-follow/index.tsx
+++ b/apps/web/components/social-follow/index.tsx
@@ -1,0 +1,2 @@
+export { SocialFollow } from "./social-follow";
+export type { SocialLink, SocialPlatform } from "./social-follow";

--- a/apps/web/components/social-follow/social-follow.tsx
+++ b/apps/web/components/social-follow/social-follow.tsx
@@ -1,0 +1,119 @@
+import React from "react";
+import { Icons } from "@repo/ui/components/icons";
+import { Button } from "@repo/ui/components/button";
+import { cn } from "@repo/ui/lib/utils";
+
+export type SocialPlatform =
+  | "twitter"
+  | "facebook"
+  | "instagram"
+  | "linkedin"
+  | "youtube"
+  | "github"
+  | "rss"
+  | "email";
+
+export type SocialLink = {
+  platform: SocialPlatform;
+  url: string;
+  label?: string;
+};
+
+type SocialFollowProps = {
+  links: SocialLink[];
+  className?: string;
+  variant?: "default" | "ghost" | "outline";
+  size?: "default" | "sm" | "lg" | "icon";
+  showLabels?: boolean;
+};
+
+const platformConfig: Record<
+  SocialPlatform,
+  { icon: keyof typeof Icons; defaultLabel: string; ariaLabel: string }
+> = {
+  twitter: {
+    icon: "twitter",
+    defaultLabel: "Twitter",
+    ariaLabel: "Follow on Twitter",
+  },
+  facebook: {
+    icon: "facebook",
+    defaultLabel: "Facebook",
+    ariaLabel: "Follow on Facebook",
+  },
+  instagram: {
+    icon: "instagram",
+    defaultLabel: "Instagram",
+    ariaLabel: "Follow on Instagram",
+  },
+  linkedin: {
+    icon: "linkedin",
+    defaultLabel: "LinkedIn",
+    ariaLabel: "Follow on LinkedIn",
+  },
+  youtube: {
+    icon: "youtube",
+    defaultLabel: "YouTube",
+    ariaLabel: "Subscribe on YouTube",
+  },
+  github: {
+    icon: "gitHub",
+    defaultLabel: "GitHub",
+    ariaLabel: "Follow on GitHub",
+  },
+  rss: { icon: "rss", defaultLabel: "RSS Feed", ariaLabel: "Subscribe to RSS" },
+  email: {
+    icon: "mail",
+    defaultLabel: "Email",
+    ariaLabel: "Subscribe via Email",
+  },
+};
+
+const SocialFollow: React.FC<SocialFollowProps> = ({
+  links,
+  className,
+  variant = "outline",
+  size = "icon",
+  showLabels = false,
+}) => {
+  if (!links || links.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className={cn("flex flex-wrap items-center gap-2", className)}>
+      {links.map((link, index) => {
+        const config = platformConfig[link.platform];
+        if (!config) {
+          console.warn(`Unknown platform: ${link.platform}`);
+          return null;
+        }
+
+        const Icon = Icons[config.icon];
+        const label = link.label || config.defaultLabel;
+
+        return (
+          <Button
+            key={`${link.platform}-${index}`}
+            variant={variant}
+            size={size}
+            asChild
+          >
+            <a
+              href={link.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label={config.ariaLabel}
+              title={label}
+            >
+              <Icon className={cn("h-5 w-5", showLabels && "mr-2")} />
+              {showLabels && <span>{label}</span>}
+            </a>
+          </Button>
+        );
+      })}
+    </div>
+  );
+};
+
+export { SocialFollow };

--- a/apps/web/constants/api.ts
+++ b/apps/web/constants/api.ts
@@ -1,5 +1,5 @@
 export const SITE_INFO_QUERY_PARAMS =
-  "fields[0]=name&fields[1]=tagline&fields[2]=email&populate[logoLight]=*&populate[logoDark]=*&populate[socialShareImage]=*&populate[footerLinkColumns][fields][0]=title&populate[footerLinkColumns][populate][links]=*&populate[navLinks]=*";
+  "fields[0]=name&fields[1]=tagline&fields[2]=email&populate[logoLight]=*&populate[logoDark]=*&populate[socialShareImage]=*&populate[footerLinkColumns][fields][0]=title&populate[footerLinkColumns][populate][links]=*&populate[navLinks]=*&populate[socialLinks]=*";
 
 export const PAGE_QUERY_PARAMS =
   "fields[0]=title&fields[1]=slug&fields[2]=description&fields[3]=content&fields[4]=isContact&populate[featuredImage]=*";

--- a/apps/web/types/api.ts
+++ b/apps/web/types/api.ts
@@ -41,6 +41,13 @@ export type APIFooterColumnType = {
   links: APILinkType[];
 };
 
+export type APISocialLinkType = {
+  id: number;
+  platform: "twitter" | "facebook" | "instagram" | "linkedin" | "youtube" | "github" | "rss" | "email";
+  url: string;
+  label?: string;
+};
+
 export type APISiteInfoType = {
   id: number;
   name: string;
@@ -51,6 +58,7 @@ export type APISiteInfoType = {
   socialShareImage: APIImageType;
   footerLinkColumns: APIFooterColumnType[];
   navLinks: APILinkType[];
+  socialLinks?: APISocialLinkType[];
 };
 
 export type APIPageType = {

--- a/packages/ui/src/components/icons.tsx
+++ b/packages/ui/src/components/icons.tsx
@@ -51,6 +51,7 @@ import {
   RectangleHorizontal,
   RectangleVertical,
   RotateCcw,
+  Rss,
   Search,
   Settings,
   Smile,
@@ -66,6 +67,11 @@ import {
   Ungroup,
   WrapText,
   X,
+  Mail,
+  Linkedin,
+  Facebook,
+  Instagram,
+  Youtube,
 } from "lucide-react";
 
 import type { LucideIcon } from "lucide-react";
@@ -280,6 +286,12 @@ export const Icons = {
   moon: Moon,
   sun: SunMedium,
   twitter: Twitter,
+  rss: Rss,
+  mail: Mail,
+  linkedin: Linkedin,
+  facebook: Facebook,
+  instagram: Instagram,
+  youtube: Youtube,
 };
 
 export const iconVariants = cva("", {


### PR DESCRIPTION
This commit adds a reusable social follow/subscribe component that allows users to:
- Follow on social media platforms (Twitter, Facebook, Instagram, LinkedIn, YouTube, GitHub)
- Subscribe via RSS feed
- Subscribe via email

Changes:
- Added social media icons (Twitter, Facebook, Instagram, LinkedIn, YouTube, RSS, Mail) to UI package
- Created SocialFollow component with configurable variants and sizes
- Added social-link component schema to Strapi CMS
- Updated site-info schema to include socialLinks field
- Updated TypeScript types to support APISocialLinkType
- Updated API query params to fetch social links

🤖 Generated with [Claude Code](https://claude.com/claude-code)